### PR TITLE
Prevent generation of empty fragments

### DIFF
--- a/pychemy/chem_structure.py
+++ b/pychemy/chem_structure.py
@@ -1,7 +1,7 @@
 from elements import ELEMENTS
 import networkx as nx
 from collections import OrderedDict
-import openbabel 
+import openbabel
 import matplotlib.pyplot as plt
 
 class chem_graph():
@@ -9,10 +9,10 @@ class chem_graph():
   def __init__(self, OBMol = None, graph = None, is_fragment = False, parent = None):
     G = None
     if OBMol:
-      G = chem_graph.graph_from_OBMol(OBMol)      
+      G = chem_graph.graph_from_OBMol(OBMol)
     elif graph:
       G = nx.Graph(graph)
-    
+
     self.G = nx.Graph(G)
 
     if is_fragment:
@@ -38,7 +38,9 @@ class chem_graph():
           for n in include:
             G.remove_node(n)
           frag += chem_graph(graph=G, is_fragment = True, parent = self.parent).gen_frag(num-1)
-      return [f for f in frag if f]
+
+      # Keep only the non-empty fragments
+      return [f for f in frag if f.G.nodes()]
 
   def chem_formula(self):
     atoms = dict()
@@ -70,7 +72,7 @@ class chem_graph():
 
     # Generate 2d positions
     openbabel.OBOp.FindType("gen2d").Do(mol)
-    
+
     for atom in openbabel.OBMolAtomIter(mol):
       idx = atom.GetIdx()
 
@@ -85,10 +87,10 @@ class chem_graph():
       atom1 = bond.GetBeginAtom().GetIdx()
       atom2 = bond.GetEndAtom().GetIdx()
       G.add_edge(atom1, atom2)
-      G[atom1][atom2]['order'] = bond.GetBO()  
-  
+      G[atom1][atom2]['order'] = bond.GetBO()
+
     return G
-  
+
   def draw(self, node_color = (1,1,1), edge_color = [0,0,0], node_size = 700, font_color = [0,0,0]):
     node_colors = [node_color for i in range(self.G.number_of_nodes())]
     edge_colors = [edge_color for i in range(self.G.number_of_edges())]
@@ -98,7 +100,7 @@ class chem_graph():
     for n in self.G.nodes():
       pos_dict[n] = [self.G.node[n]['X'], self.G.node[n]['Y']]
       label_dict[n] = self.G.node[n]['atom'].symbol
-    
+
     # Draw single bonds
     nx.draw(self.G,
             pos = pos_dict,
@@ -142,7 +144,7 @@ class chem_graph():
             width = [2 for i in widths],
             edgelist = edge_list
             )
-    
+
     # Draw triple bonds
     edge_list = [edge for edge in self.G.edges() if self.G[edge[0]][edge[1]]['order'] == 3]
     nx.draw(self.G,
@@ -172,7 +174,7 @@ class chem_graph():
             width = [6 for i in widths],
             edgelist = edge_list
             )
-     
+
     nx.draw(self.G,
             pos = pos_dict,
             labels = label_dict,
@@ -191,7 +193,7 @@ class chem_graph():
     if self.parent:
       w = 0.95
       self.parent.draw(edge_color = [w,w,w],
-                font_color = [w,w,w], 
+                font_color = [w,w,w],
                 node_size = 600,
                 )
     self.draw()
@@ -208,7 +210,7 @@ class chem_structure():
       obConversion.SetInAndOutFormats("inchi", "mdl")
       obConversion.ReadString(self.mol, inchi)
       self.mol.AddHydrogens()
- 
+
   def chem_formula(self):
     return self.mol.GetSpacedFormula()
 
@@ -222,4 +224,4 @@ class chem_structure():
       nodes = tuple(sorted([n for n in item.G.nodes()]))
       if nodes not in u.keys():
         u[nodes] = item
-    return [u[key] for key in u]  
+    return [u[key] for key in u]

--- a/pychemy/tests/test_CS.py
+++ b/pychemy/tests/test_CS.py
@@ -6,14 +6,14 @@ from pychemy.elements import ELEMENTS
 
 inchi1 = 'InChI=1/C5H5N5O/c6-5-9-3-2(4(11)10-5)7-1-8-3/h1H,(H4,6,7,8,9,10,11)/f/h8,10H,6H2'
 
-#Aspirine
+# Aspirine
 inchi2 = 'InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)'
 
 class chem_structure_Testing(unittest.TestCase):
 
 
-###############################
-# chem_structure
+  ###############################
+  # chem_structure
 
   def test_chem_structure_without_input(self):
     CS = cs()
@@ -25,8 +25,8 @@ class chem_structure_Testing(unittest.TestCase):
     self.assertEqual(CS.mol.NumAtoms(), 16)
     self.assertEqual(CS.mol.NumBonds(), 17)
 
-###############################
-# chem_graph
+  ###############################
+  # chem_graph
 
   def test_graph_from_OBMol(self):
     CS = cs(inchi = inchi1)
@@ -59,23 +59,23 @@ class chem_structure_Testing(unittest.TestCase):
       self.assertTrue('order' in G[e[0]][e[1]])
 
     self.assertEqual(G.number_of_edges(), 17)
-    edge_set = [(1,12),(12,1),
-                (1,7),(7,1),
-                (1,8),(8,1),
-                (2,7),(7,2),
-                (3,8),(8,3),
-                (2,3),(3,2),
-                (2,4),(4,2),
-                (4,11),(11,4),
-                (4,10),(10,4),
-                (10,16),(16,10),
-                (5,10),(10,5),
-                (5,6),(6,5),
-                (5,9),(9,5),
-                (3,9),(9,3),
-                (8,15),(15,8),
-                (6,13),(13,6),
-                (6,14),(14,6)]
+    edge_set = [(1, 12), (12,  1),
+                (1,  7),  (7,  1),
+                (1,  8),  (8,  1),
+                (2,  7),  (7,  2),
+                (3,  8),  (8,  3),
+                (2,  3),  (3,  2),
+                (2,  4),  (4,  2),
+                (4, 11), (11,  4),
+                (4, 10), (10,  4),
+               (10, 16), (16, 10),
+                (5, 10), (10,  5),
+                (5,  6),  (6,  5),
+                (5,  9),  (9,  5),
+                (3,  9),  (9,  3),
+                (8, 15), (15,  8),
+                (6, 13), (13,  6),
+                (6, 14), (14,  6)]
 
     for e in G.edges():
       self.assertIn(e,edge_set)

--- a/pychemy/tests/test_CS.py
+++ b/pychemy/tests/test_CS.py
@@ -9,11 +9,11 @@ inchi1 = 'InChI=1/C5H5N5O/c6-5-9-3-2(4(11)10-5)7-1-8-3/h1H,(H4,6,7,8,9,10,11)/f/
 #Aspirine
 inchi2 = 'InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)'
 
-class chem_structure_Testing(unittest.TestCase):   
+class chem_structure_Testing(unittest.TestCase):
 
 
 ###############################
-# chem_structure  
+# chem_structure
 
   def test_chem_structure_without_input(self):
     CS = cs()
@@ -33,7 +33,7 @@ class chem_structure_Testing(unittest.TestCase):
     G = cg.graph_from_OBMol(CS.mol)
 
     self.assertEqual(G.number_of_nodes(), 16)
-    
+
     self.assertEqual(G.node[1]['atom'], ELEMENTS['C'])
     self.assertEqual(G.node[2]['atom'], ELEMENTS['C'])
     self.assertEqual(G.node[3]['atom'], ELEMENTS['C'])
@@ -75,8 +75,8 @@ class chem_structure_Testing(unittest.TestCase):
                 (3,9),(9,3),
                 (8,15),(15,8),
                 (6,13),(13,6),
-                (6,14),(14,6)] 
-    
+                (6,14),(14,6)]
+
     for e in G.edges():
       self.assertIn(e,edge_set)
       edge_set.remove(e)
@@ -97,7 +97,7 @@ class chem_structure_Testing(unittest.TestCase):
   def test_chem_formula(self):
     CS = cs(inchi = inchi1)
     CG = cg(CS.mol)
-    self.assertEqual(CG.chem_formula(),CS.chem_formula()) 
+    self.assertEqual(CG.chem_formula(),CS.chem_formula())
 
   def test_mass(self):
     CS = cs(inchi = inchi1)
@@ -107,7 +107,7 @@ class chem_structure_Testing(unittest.TestCase):
   def test_gen_frag_with_no_additional_steps(self):
     CS = cs(inchi = inchi1)
     CG = cg(CS.mol)
-    self.assertEqual(CG.gen_frag(0), [CG])   
+    self.assertEqual(CG.gen_frag(0), [CG])
 
   def test_gen_frag_with_additional_steps_uniqueness(self):
     CS = cs(inchi = inchi1)

--- a/pychemy/tests/test_CS.py
+++ b/pychemy/tests/test_CS.py
@@ -109,9 +109,18 @@ class chem_structure_Testing(unittest.TestCase):
     CG = cg(CS.mol)
     self.assertEqual(CG.gen_frag(0), [CG])
 
+  def test_gen_frag_has_no_empty_molecules(self):
+    CS = cs(inchi = inchi1)
+    CG = cg(CS.mol)
+    for level in xrange(0, 4):
+      frag = CG.gen_frag(level)
+      nonempty_frag = filter(lambda f: len(f.chem_formula()) > 0, frag)
+      self.assertEqual(frag, nonempty_frag)
+
+
   def test_gen_frag_with_additional_steps_uniqueness(self):
     CS = cs(inchi = inchi1)
     CG = cg(CS.mol)
-    for level in range(1,4):
+    for level in range(1, 4):
       frag = CG.gen_frag(level)
       self.assertEqual(len(frag), len(set(frag)))


### PR DESCRIPTION
These commits fix the original attempt to prevent gen_frag from returning empty fragments. They also do a bit of cleanup and standardization.

Fixes #5 and #4.
